### PR TITLE
Add Feature - Handle Multicast Requests

### DIFF
--- a/coap_interaction.h
+++ b/coap_interaction.h
@@ -38,7 +38,7 @@ typedef enum
 	COAP_STATE_HANDLE_REQUEST, 					// Remote request received & parsed -> invoke resource handler
 	COAP_STATE_RESOURCE_POSTPONE_EMPTY_ACK_SENT,// Wait some time for resource to become ready, meanwhile empty ack has been sent
 	COAP_STATE_RESPONSE_SENT,					// NON or piggy-ACK response has been sent -> wait some time then delete
-												// CON response has been sent (+previous separate ACK of req)
+	COAP_STATE_RESPONSE_WAITING_LEISURE,		// CON response has been sent (+previous separate ACK of req)
 												// -> wait for ACK or resent after some time
 
 	//[notificator]

--- a/coap_main.c
+++ b/coap_main.c
@@ -192,7 +192,7 @@ static CoAP_Result_t _rom SendResp(CoAP_Interaction_t* pIA, CoAP_InteractionStat
 
 		pIA->State = nextIAState; //move to next state
 
-		CoAP_EnqueueLastInteraction(pIA); //(re)enqueue interaction for further processing//todo: in die �u�ere statemachine
+		CoAP_EnqueueLastInteraction(pIA); //(re)enqueue interaction for further processing//todo: in die äußere statemachine
 
 	}else { //unexspected internal failure todo: try at least to send 4 byte RESP_INTERNAL_SERVER_ERROR_5_00
 		INFO("(!!!) SendResp(): Internal socket error on sending response! MiD: %d", pIA->pReqMsg->MessageID );
@@ -213,7 +213,7 @@ static CoAP_Result_t _rom SendReq(CoAP_Interaction_t* pIA, CoAP_InteractionState
 
 		pIA->State = nextIAState; //move to next state
 
-		CoAP_EnqueueLastInteraction(pIA); //(re)enqueue interaction for further processing//todo: in die �u�ere statemachine
+		CoAP_EnqueueLastInteraction(pIA); //(re)enqueue interaction for further processing//todo: in die äußere statemachine
 
 	}else { //unexspected internal failure todo: try at least to send 4 byte RESP_INTERNAL_SERVER_ERROR_5_00
 		INFO("(!!!) SendReq(): Internal socket error on sending response! MiD: %d", pIA->pReqMsg->MessageID );
@@ -342,7 +342,7 @@ void _rom CoAP_doWork()
 			if(pIA->ReqMetaInfo.Type == META_INFO_MULTICAST){
 				// Messages sent via multicast MUST be NON-confirmable.
 				if(pIA->pReqMsg->Type == CON){
-					INFO("Request received from multicast endpoint is not allowed" );
+					INFO("Request received from multicast endpoint is not allowed");
 					CoAP_DeleteInteraction(pIA);
 					return;
 				}
@@ -387,16 +387,18 @@ void _rom CoAP_doWork()
 			//Check return value of handler:
 			//a) everything fine - we got an response to send
 			if(Res == HANDLER_OK) {
-				if(pIA->pRespMsg->Code == EMPTY)
+				if(pIA->pRespMsg->Code == EMPTY) {
 					pIA->pRespMsg->Code = RESP_SUCCESS_CONTENT_2_05; //handler forgot to set code?
+				}
 
 			//b) handler has no result and will not deliver	in the future
 			} else if(Res == HANDLER_ERROR) {
-				if(pIA->pRespMsg->Code == EMPTY)
+				if(pIA->pRespMsg->Code == EMPTY) {
 					pIA->pRespMsg->Code = RESP_INTERNAL_SERVER_ERROR_5_00; //handler forgot to set code?
+				}
 
 				// Don't respond with reset or empty messages to requests originating from multicast enpoints
-				if(pIA->ReqMetaInfo.Type == META_INFO_MULTICAST){
+				if(pIA->ReqMetaInfo.Type == META_INFO_MULTICAST) {
 					CoAP_DeleteInteraction(pIA);
 					return;
 				}

--- a/interface/network/net_Endpoint.c
+++ b/interface/network/net_Endpoint.c
@@ -24,8 +24,13 @@
 
 const NetAddr_IPv6_t NetAddr_IPv6_unspecified = {.u8 = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }};
 const NetAddr_IPv6_t NetAddr_IPv6_mulitcast = {.u8 = {0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }};
+const NetAddr_IPv4_t NetAddr_IPv4_unspecified = { .u8 = { 0, 0, 0, 0 } };
+const NetAddr_IPv4_t NetAddr_IPv4_mulitcast = { .u8 = { 224, 0, 1, 187 } };
 
- bool _rom EpAreEqual(NetEp_t* ep_A, NetEp_t* ep_B)
+const NetEp_t NetEp_IPv6_mulitcast = { .NetType = IPV6, .NetPort = 5683, .NetAddr = { .IPv6 = {.u8 = {0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 } } } };
+const NetEp_t NetEp_IPv4_mulitcast = { .NetType = IPV4, .NetPort = 5683, .NetAddr = { .IPv4 = { .u8 = { 224, 0, 1, 187 } } } };
+
+ bool _rom EpAreEqual(const NetEp_t* ep_A, const NetEp_t* ep_B)
  {
 	 if(!ep_A || !ep_B){return false;}
 	 if(ep_A->NetType != ep_B->NetType){return false;}
@@ -52,12 +57,12 @@ const NetAddr_IPv6_t NetAddr_IPv6_mulitcast = {.u8 = {0xff, 0x02, 0, 0, 0, 0, 0,
 	 return true;
  }
 
- void _rom CopyEndpoints(NetEp_t* Destination, NetEp_t* Source)
+ void _rom CopyEndpoints(NetEp_t* Destination, const NetEp_t* Source)
  {
 	 memmove((void*)Destination, (void*)Source, sizeof(NetEp_t));
  }
 
- void _rom PrintEndpoint(NetEp_t* ep)
+ void _rom PrintEndpoint(const NetEp_t* ep)
  {
 	 /*
 	if(ep->NetType == IPV6)

--- a/interface/network/net_Endpoint.h
+++ b/interface/network/net_Endpoint.h
@@ -77,9 +77,14 @@ typedef struct
 
 extern const NetAddr_IPv6_t NetAddr_IPv6_unspecified;
 extern const NetAddr_IPv6_t NetAddr_IPv6_mulitcast;
+extern const NetAddr_IPv4_t NetAddr_IPv4_unspecified;
+extern const NetAddr_IPv4_t NetAddr_IPv4_mulitcast;
 
-bool EpAreEqual(NetEp_t* ep_A, NetEp_t* ep_B);
-void PrintEndpoint(NetEp_t* ep);
-void CopyEndpoints(NetEp_t* Source, NetEp_t* Destination);
+extern const NetEp_t NetEp_IPv6_mulitcast;
+extern const NetEp_t NetEp_IPv4_mulitcast;
+
+bool EpAreEqual(const NetEp_t* ep_A, const NetEp_t* ep_B);
+void PrintEndpoint(const NetEp_t* ep);
+void CopyEndpoints(NetEp_t* Destination, const NetEp_t* Source);
 
 #endif

--- a/interface/network/net_Packet.h
+++ b/interface/network/net_Packet.h
@@ -25,7 +25,8 @@
 typedef enum
 {
 	META_INFO_NONE,
-	META_INFO_RF_PATH
+	META_INFO_RF_PATH,
+	META_INFO_MULTICAST,
 }MetaInfoType_t;
 
 typedef struct


### PR DESCRIPTION
I'm working on device discovery and saw this wasn't supported in this library. 

When the application layer receives a messaged that was sent via Multicast; It must set `NetPacket_t.MetaInfo.Type = META_INFO_MULTICAST` before handing off to `NetSocket_t`'s `RxCB(...)` 

Example code with NetConn API (LWIP stack)
```c
// struct netbuf* buffer = ...
 if( buffer->toaddr.type == IPADDR_TYPE_V4 )
    {
        packet.Receiver.NetType = IPV4;
        packet.Receiver.NetAddr.IPv4.u32[0] = ip_addr_get_ip4_u32( &buffer->toaddr );
     
        INFO( "Packet sent to %s:%hu", ipaddr_ntoa( &buffer->toaddr ), packet.Receiver.NetPort );
    }
    else if( buffer->addr.type == IPADDR_TYPE_V6 )
    {
        packet.Receiver.NetType = IPV6;
        packet.Receiver.NetAddr.IPv6.u32[0] = ip_2_ip6( &buffer->toaddr )->addr[0];
        packet.Receiver.NetAddr.IPv6.u32[1] = ip_2_ip6( &buffer->toaddr )->addr[1];
        packet.Receiver.NetAddr.IPv6.u32[2] = ip_2_ip6( &buffer->toaddr )->addr[2];
        packet.Receiver.NetAddr.IPv6.u32[3] = ip_2_ip6( &buffer->toaddr )->addr[3];

        INFO( "Packet sent to [%s]:%hu", ipaddr_ntoa( &buffer->toaddr ), packet.Receiver.NetPort );
    }

    if( EpAreEqual( &packet.Receiver, &NetEp_IPv4_mulitcast ) || EpAreEqual( &packet.Receiver, &NetEp_IPv6_mulitcast ) )
        packet.MetaInfo.Type = META_INFO_MULTICAST;
```