### PR TITLE
Only use Non-Cross Compiler Preprocess `#pragma` in MSVC

### DIFF
--- a/src/interface/debug/coap_debug.h
+++ b/src/interface/debug/coap_debug.h
@@ -22,7 +22,9 @@
 #ifndef COM_DEBUG_H
 #define COM_DEBUG_H
 
-#pragma warning( disable : 4996 )
+#if _MSC_VER
+	#pragma warning( disable : 4996 )
+#endif
 
 #define DEBUG_BUF_SIZE (500)
 extern char dbgBuf[DEBUG_BUF_SIZE];


### PR DESCRIPTION
Pretty simple. this prevents compilers that aren't Microsoft's Visual C++ compiler from throwing an error