### PR TITLE
Fix compile errors from API refactor

### DIFF
--- a/src/coap_options.c
+++ b/src/coap_options.c
@@ -332,7 +332,7 @@ CoAP_option_t* _rom CoAP_FindOptionByNumber(CoAP_Message_t* msg, uint16_t number
 }
 
 CoAP_Result_t _rom CoAP_AddOption(CoAP_Message_t* pMsg, uint16_t OptNumber, uint8_t* buf, uint16_t length) {
-	CoAP_AppendOptionToList(&pMsg->pOptionsList, OptNumber, buf, length);
+	return CoAP_AppendOptionToList(&pMsg->pOptionsList, OptNumber, buf, length);
 }
 
 // this function adds a new option to linked list of options starting at pOptionsListBegin

--- a/src/coap_resource.c
+++ b/src/coap_resource.c
@@ -196,16 +196,16 @@ CoAP_HandlerResult_t _rom WellKnown_GetHandler(CoAP_Message_t* pReq, CoAP_Messag
 		*pStr = '<';
 		pStr++;
 		while (pUriOpt != NULL) {
+			*pStr = '/';
 			coap_memcpy(pStr, pUriOpt->Value, pUriOpt->Length);
 			pStr += pUriOpt->Length;
-			*pStr = '/';
 			pStr++;
 			pUriOpt = pUriOpt->next;
 		}
 		if (pList->Options.Cf == COAP_CF_LINK_FORMAT) {
 			pStr += coap_sprintf((char*) pStr, ">,");
 		} else {
-			pStr += coap_sprintf((char*) pStr, ">;title=\"%s\";cf=%d", pList->pDescription, pList->Options.Cf);
+			pStr += coap_sprintf((char *) pStr, ">;title=\"%s\";ct=%d", pList->pDescription, pList->Options.Cf);
 			if (pList->Notifier != NULL) {
 				pStr += coap_sprintf((char*) pStr, ";obs,");
 			} else {

--- a/src/interface/debug/coap_debug.h
+++ b/src/interface/debug/coap_debug.h
@@ -22,8 +22,6 @@
 #ifndef COM_DEBUG_H
 #define COM_DEBUG_H
 
-#pragma warning( disable : 4996 )
-
 #define DEBUG_BUF_SIZE (500)
 extern char dbgBuf[DEBUG_BUF_SIZE];
 

--- a/src/interface/network/net_Socket.c
+++ b/src/interface/network/net_Socket.c
@@ -40,7 +40,7 @@ CoAP_Socket_t* _rom AllocSocket() {
 	for (i = 0; i < MAX_ACTIVE_SOCKETS; i++) {
 		CoAP_Socket_t* socket = &(SocketCtrl.SocketMemory[i]);
 		if (socket->Alive == false) {
-			memset(socket, 0, sizeof(socket));
+			memset(socket, 0, sizeof(*socket));
 			socket->Alive = true;
 			return socket;
 		}


### PR DESCRIPTION
I've got my compiler set to treat warnings as errors, surprisingly, not much was needed to clear out the errors. Yes this does break #8 for now. Can still address that when we need it