### PR TITLE
Add support for Accept option 

### DIFF
--- a/src/coap_options.c
+++ b/src/coap_options.c
@@ -23,7 +23,8 @@
 #include "coap.h"
 
 // Used in Critical Option Check.
-uint16_t KNOWN_OPTIONS[KNOWN_OPTIONS_COUNT] = { OPT_NUM_URI_PATH, OPT_BLOCK2, OPT_BLOCK1, OPT_NUM_ETAG, OPT_NUM_CONTENT_FORMAT, OPT_NUM_URI_QUERY, OPT_NUM_ACCEPT };
+uint16_t KNOWN_OPTIONS[] = { OPT_NUM_URI_PATH, OPT_BLOCK2, OPT_BLOCK1, OPT_NUM_ETAG, OPT_NUM_CONTENT_FORMAT, OPT_NUM_URI_QUERY, OPT_NUM_ACCEPT };
+size_t KNOWN_OPTIONS_COUNT = sizeof(KNOWN_OPTIONS) / sizeof(KNOWN_OPTIONS[0]);
 
 //#########################################################################################################
 //### This function packs multiple CoAP options to the format specified at

--- a/src/coap_options.c
+++ b/src/coap_options.c
@@ -23,7 +23,7 @@
 #include "coap.h"
 
 // Used in Critical Option Check.
-uint16_t KNOWN_OPTIONS[KNOWN_OPTIONS_COUNT] = { OPT_NUM_URI_PATH, OPT_BLOCK2, OPT_BLOCK1, OPT_NUM_ETAG, OPT_NUM_CONTENT_FORMAT, OPT_NUM_URI_QUERY };
+uint16_t KNOWN_OPTIONS[KNOWN_OPTIONS_COUNT] = { OPT_NUM_URI_PATH, OPT_BLOCK2, OPT_BLOCK1, OPT_NUM_ETAG, OPT_NUM_CONTENT_FORMAT, OPT_NUM_URI_QUERY, OPT_NUM_ACCEPT };
 
 //#########################################################################################################
 //### This function packs multiple CoAP options to the format specified at
@@ -334,6 +334,42 @@ CoAP_option_t* _rom CoAP_FindOptionByNumber(CoAP_Message_t* msg, uint16_t number
 CoAP_Result_t _rom CoAP_AddOption(CoAP_Message_t* pMsg, uint16_t OptNumber, uint8_t* buf, uint16_t length) {
 	CoAP_AppendOptionToList(&pMsg->pOptionsList, OptNumber, buf, length);
 }
+
+CoAP_Result_t _rom CoAP_AppendUintOptionToList(CoAP_option_t** pOptionsListBegin, uint16_t OptNumber, uint32_t val) { 
+	uint8_t wBuf[4]; 
+
+	if(val==0) 
+	{ 
+		CoAP_AppendOptionToList(pOptionsListBegin, OptNumber ,wBuf, 0); 
+	} 
+	else if(val <= 0xff) 
+	{ 
+		wBuf[0]=(uint8_t)val; 
+		CoAP_AppendOptionToList(pOptionsListBegin, OptNumber ,wBuf, 1); 
+	} 
+	else if(val <= 0xffff) 
+	{ 
+		wBuf[0]=(uint8_t)(val & 0xff); 
+		wBuf[1]=(uint8_t)(val>>8); 
+		CoAP_AppendOptionToList(pOptionsListBegin, OptNumber ,wBuf, 2); 
+	} 
+	else if(val <= 0xffffff) 
+	{ 
+		wBuf[0]=(uint8_t)(val & 0xff); 
+		wBuf[1]=(uint8_t)((val>>8) & 0xff); 
+		wBuf[2]=(uint8_t)(val>>16); 
+		CoAP_AppendOptionToList(pOptionsListBegin, OptNumber ,wBuf, 3); 
+	} 
+	else { 
+		wBuf[0]=(uint8_t)(val & 0xff); 
+		wBuf[1]=(uint8_t)((val>>8) & 0xff); 
+		wBuf[2]=(uint8_t)((val>>16) & 0xff); 
+		wBuf[3]=(uint8_t)(val>>24); 
+		CoAP_AppendOptionToList(pOptionsListBegin, OptNumber ,wBuf, 4); 
+	} 
+
+	return COAP_OK; 
+} 
 
 // this function adds a new option to linked list of options starting at pOptionsListBegin
 // on demand the list gets reordered so that it's sorted ascending by option number (CoAP requirement)

--- a/src/coap_options.h
+++ b/src/coap_options.h
@@ -42,8 +42,8 @@ typedef enum
 
 //on addition of an option also change coap_options.C (array initializer) and count
 //Proxy-Uri
-#define KNOWN_OPTIONS_COUNT (7)
-extern uint16_t KNOWN_OPTIONS[KNOWN_OPTIONS_COUNT];
+extern size_t KNOWN_OPTIONS_COUNT;
+extern uint16_t KNOWN_OPTIONS[];
 
 #define OPT_FLAG_CRITICAL 	(1<<0)
 #define OPT_FLAG_UNSAFE	  	(1<<1)

--- a/src/coap_options.h
+++ b/src/coap_options.h
@@ -33,6 +33,7 @@ typedef enum
 	OPT_NUM_URI_PORT = 7,
 	OPT_NUM_CONTENT_FORMAT = 12,
 	OPT_NUM_URI_QUERY = 15,
+	OPT_NUM_ACCEPT = 17, 
 //Blockwise transfers
 	OPT_BLOCK2 = 23,
 	OPT_BLOCK1 = 27,
@@ -41,7 +42,7 @@ typedef enum
 
 //on addition of an option also change coap_options.C (array initializer) and count
 //Proxy-Uri
-#define KNOWN_OPTIONS_COUNT (6)
+#define KNOWN_OPTIONS_COUNT (7)
 extern uint16_t KNOWN_OPTIONS[KNOWN_OPTIONS_COUNT];
 
 #define OPT_FLAG_CRITICAL 	(1<<0)
@@ -58,6 +59,7 @@ CoAP_Result_t pack_OptionsFromList(uint8_t* pDestArr, uint16_t* pBytesWritten, C
 uint16_t  CoAP_NeededMem4PackOptions(CoAP_option_t* pOptionsListBegin);
 
 CoAP_option_t* CoAP_FindOptionByNumber(CoAP_Message_t* msg, uint16_t number);
+CoAP_Result_t CoAP_AppendUintOptionToList(CoAP_option_t** pOptionsListBegin, uint16_t OptNumber, uint32_t val); 
 CoAP_Result_t CoAP_AppendOptionToList(CoAP_option_t** pOptionsListBegin, uint16_t OptNumber, uint8_t* buf, uint16_t length);
 CoAP_Result_t CoAP_CopyOptionToList(CoAP_option_t** pOptionsListBegin, CoAP_option_t* OptToCopy);
 CoAP_Result_t CoAP_RemoveOptionFromList(CoAP_option_t** pOptionListStart, CoAP_option_t* pOptionToRemove);

--- a/src/coap_resource.c
+++ b/src/coap_resource.c
@@ -221,7 +221,7 @@ CoAP_HandlerResult_t _rom WellKnown_GetHandler(CoAP_Message_t* pReq, CoAP_Messag
 	CoAP_SetPayload(pResp, pStrStart, (uint16_t) coap_strlen((char*) pStrStart), true);
 	coap_mem_release(pStrStart);
 
-	AddCfOptionToMsg(pResp, COAP_CF_LINK_FORMAT);
+	CoAP_AddCfOptionToMsg(pResp, COAP_CF_LINK_FORMAT);
 
 	return HANDLER_OK;
 }

--- a/src/option-types/coap_option_cf.c
+++ b/src/option-types/coap_option_cf.c
@@ -24,26 +24,46 @@
 //add content-format option
 CoAP_Result_t _rom AddCfOptionToMsg(CoAP_Message_t* msg, uint16_t cf)
 {
-	uint8_t wBuf[2];
+	return CoAP_AddCfOptionToMsg(msg, cf);
+}
 
-	//msg->Options[msg->OptionCount].Number = OPT_NUM_CONTENT_FORMAT;
-	if(cf==0)
+CoAP_Result_t _rom CoAP_AddCfOptionToMsg(CoAP_Message_t* msg, uint16_t contentFormat)
+{
+	return CoAP_AppendUintOptionToList(&(msg->pOptionsList), OPT_NUM_CONTENT_FORMAT, contentFormat);
+}
+
+CoAP_Result_t _rom CoAP_AddAcceptOptionToMsg(CoAP_Message_t* msg, uint16_t contentFormat)
+{
+	return CoAP_AppendUintOptionToList(&(msg->pOptionsList), OPT_NUM_ACCEPT, contentFormat);
+}
+
+uint16_t _rom CoAP_GetAcceptOptionVal(CoAP_option_t* pAcceptOpt)
+{
+	if(pAcceptOpt == NULL) return 0;
+	if(pAcceptOpt->Number != OPT_NUM_ACCEPT) return 0;
+	if(pAcceptOpt->Length == 0 || pAcceptOpt->Length > 2) return 0;
+
+	uint16_t retVal = 0;
+	if(pAcceptOpt->Length == 1)
 	{
-		//msg->Options[msg->OptionCount].Length = 0;
-		CoAP_AppendOptionToList(&(msg->pOptionsList), OPT_NUM_CONTENT_FORMAT ,wBuf, 0);
+		retVal = pAcceptOpt->Value[0];
 	}
-	else if(cf <= 0xff)
+	else if(pAcceptOpt->Length == 2)
 	{
-		wBuf[0]=(uint8_t)cf;
-		//msg->Options[msg->OptionCount].Length = 1;
-		CoAP_AppendOptionToList(&(msg->pOptionsList), OPT_NUM_CONTENT_FORMAT ,wBuf, 1);
-	}
-	else {
-		wBuf[0]=(uint8_t)(cf & 0xff);
-		wBuf[1]=(uint8_t)(cf>>8);
-		//msg->Options[msg->OptionCount].Length = 2;
-		CoAP_AppendOptionToList(&(msg->pOptionsList), OPT_NUM_CONTENT_FORMAT ,wBuf, 2);
+		retVal = pAcceptOpt->Value[0];
+		retVal |= pAcceptOpt->Value[1] << 8;
 	}
 
-	return COAP_OK;
+	return retVal;
+}
+
+uint16_t _rom CoAP_GetAcceptOptionValFromMsg(CoAP_Message_t* pMsg)
+{
+	uint16_t retVal = 0;
+	for(CoAP_option_t* pOpt =pMsg->pOptionsList ; pOpt != NULL; pOpt = pOpt->next) {
+		if(pOpt->Number != OPT_NUM_ACCEPT)
+			continue;
+		retVal = CoAP_GetAcceptOptionVal(pOpt);
+	}
+	return retVal;
 }

--- a/src/option-types/coap_option_cf.c
+++ b/src/option-types/coap_option_cf.c
@@ -21,12 +21,6 @@
  *******************************************************************************/
 #include "../coap.h"
 
-//add content-format option
-CoAP_Result_t _rom AddCfOptionToMsg(CoAP_Message_t* msg, uint16_t cf)
-{
-	return CoAP_AddCfOptionToMsg(msg, cf);
-}
-
 CoAP_Result_t _rom CoAP_AddCfOptionToMsg(CoAP_Message_t* msg, uint16_t contentFormat)
 {
 	return CoAP_AppendUintOptionToList(&(msg->pOptionsList), OPT_NUM_CONTENT_FORMAT, contentFormat);

--- a/src/option-types/coap_option_cf.h
+++ b/src/option-types/coap_option_cf.h
@@ -22,11 +22,18 @@
 #ifndef COAP_CF_OPTION
 #define COAP_CF_OPTION
 
+/**
+ * @deprecated Please use @sa CoAP_AddCfOptionToMsg
+ */
 CoAP_Result_t AddCfOptionToMsg(CoAP_Message_t* msg, uint16_t cf);
 
+CoAP_Result_t CoAP_AddCfOptionToMsg(CoAP_Message_t* msg, uint16_t cf);
+CoAP_Result_t CoAP_AddAcceptOptionToMsg(CoAP_Message_t* msg, uint16_t contentFormat);
+
+uint16_t CoAP_GetAcceptOptionVal(CoAP_option_t* pAcceptOpt);
+uint16_t CoAP_GetAcceptOptionValFromMsg(CoAP_Message_t* pMsg);
 typedef enum
 {
-	COAP_CF_NOT_DEFINIED = 0xffff,
 	COAP_CF_TEXT_PLAIN = 0,
 	COAP_CF_LINK_FORMAT = 40,
 	COAP_CF_APP_XML = 41,
@@ -34,7 +41,5 @@ typedef enum
 	COAP_CF_EXI = 47,
 	COAP_CF_JSON = 50
 }CoAP_ContentFormat_t;
-
-
 
 #endif

--- a/src/option-types/coap_option_cf.h
+++ b/src/option-types/coap_option_cf.h
@@ -39,7 +39,8 @@ typedef enum
 	COAP_CF_APP_XML = 41,
 	COAP_CF_OCTET_STREAM = 42,
 	COAP_CF_EXI = 47,
-	COAP_CF_JSON = 50
+	COAP_CF_JSON = 50,
+	COAP_CF_CBOR = 60
 }CoAP_ContentFormat_t;
 
 #endif

--- a/src/option-types/coap_option_cf.h
+++ b/src/option-types/coap_option_cf.h
@@ -22,11 +22,6 @@
 #ifndef COAP_CF_OPTION
 #define COAP_CF_OPTION
 
-/**
- * @deprecated Please use @sa CoAP_AddCfOptionToMsg
- */
-CoAP_Result_t AddCfOptionToMsg(CoAP_Message_t* msg, uint16_t cf);
-
 CoAP_Result_t CoAP_AddCfOptionToMsg(CoAP_Message_t* msg, uint16_t cf);
 CoAP_Result_t CoAP_AddAcceptOptionToMsg(CoAP_Message_t* msg, uint16_t contentFormat);
 


### PR DESCRIPTION
Accept is a critical option and the the library fails if it doesn't know about critical options. 

This adds support for the Accept (17) option header along with a few helper functions.