### PR TITLE
Client interaction: Cannot find corresponding interaction for incoming message.

### DIFF
--- a/src/coap_interaction.c
+++ b/src/coap_interaction.c
@@ -199,16 +199,9 @@ CoAP_Interaction_t* _rom CoAP_FindInteractionByMessageIdAndEp(CoAP_Interaction_t
 	// A received ACK message acknowledges a former send CON message or (optional) NON message send by us
 	// servers and notificators use CON only in responses, clients in requests
 	while (pList != NULL) {
-		if (pList->Role == COAP_ROLE_CLIENT) {
-			if (pList->pReqMsg != NULL && pList->pReqMsg->MessageID == mID && EpAreEqual(fromEp, &(pList->RemoteEp)) {
-				return pList;
-			}
-		} else {
-			if (pList->pRespMsg != NULL && pList->pRespMsg->MessageID == mID && EpAreEqual(fromEp, &(pList->RemoteEp))) {
-				return pList;
-			}
+		if ((pList->pRespMsg != NULL && pList->pRespMsg->MessageID == mID || pList->pReqMsg != NULL && pList->pReqMsg->MessageID == mID) && EpAreEqual(fromEp, &(pList->RemoteEp))) {
+			return pList;
 		}
-
 		pList = pList->next;
 	}
 

--- a/src/coap_interaction.c
+++ b/src/coap_interaction.c
@@ -199,9 +199,16 @@ CoAP_Interaction_t* _rom CoAP_FindInteractionByMessageIdAndEp(CoAP_Interaction_t
 	// A received ACK message acknowledges a former send CON message or (optional) NON message send by us
 	// servers and notificators use CON only in responses, clients in requests
 	while (pList != NULL) {
-		if (pList->pRespMsg != NULL && pList->pRespMsg->MessageID == mID && EpAreEqual(fromEp, &(pList->RemoteEp))) {
-			return pList;
+		if (pList->Role == COAP_ROLE_CLIENT) {
+			if (pList->pReqMsg != NULL && pList->pReqMsg->MessageID == mID && EpAreEqual(fromEp, &(pList->RemoteEp)) {
+				return pList;
+			}
+		} else {
+			if (pList->pRespMsg != NULL && pList->pRespMsg->MessageID == mID && EpAreEqual(fromEp, &(pList->RemoteEp))) {
+				return pList;
+			}
 		}
+
 		pList = pList->next;
 	}
 


### PR DESCRIPTION
My scenario:
- Send CON request as client
- Receive ACK, but cannot find interaction by message id.
When acting as client, the message id is stored in pList->pReqMsg not pList->pRespMsg.

This commit fixed it for me. 
Please correct me if I am wrong.