### PR TITLE
Get uint value from option

### DIFF
--- a/src/coap_options.c
+++ b/src/coap_options.c
@@ -372,6 +372,44 @@ CoAP_Result_t _rom CoAP_AppendUintOptionToList(CoAP_option_t** pOptionsListBegin
 	return COAP_OK; 
 } 
 
+CoAP_Result_t _rom CoAP_GetUintFromOption(const CoAP_option_t* pOption, uint32_t* value) {
+	if( value == NULL || pOption == NULL )
+		return COAP_ERR_ARGUMENT;
+
+	if( pOption->Length == 0 )
+	{
+		*value = 0;
+	}
+	else if( pOption->Length == 1 )
+	{
+		*value = pOption->Value[0];
+	}
+	else if( pOption->Length == 2 )
+	{
+		*value = pOption->Value[0];
+		*value |= (pOption->Value[1] << 8);
+	}
+	else if( pOption->Length == 3 )
+	{
+		*value = pOption->Value[0];
+		*value |= (pOption->Value[1] << 8);
+		*value |= (pOption->Value[2] << 16);
+	}
+	else if( pOption->Length == 4 )
+	{
+		*value = pOption->Value[0];
+		*value |= (pOption->Value[1] << 8);
+		*value |= (pOption->Value[2] << 16);
+		*value |= (pOption->Value[3] << 24);
+	}
+	else
+	{
+		return COAP_ERR_ARGUMENT;
+	}
+
+	return COAP_OK;
+}
+
 // this function adds a new option to linked list of options starting at pOptionsListBegin
 // on demand the list gets reordered so that it's sorted ascending by option number (CoAP requirement)
 // copies given buffer to option local buffer

--- a/src/coap_options.h
+++ b/src/coap_options.h
@@ -50,6 +50,8 @@ CoAP_Result_t CoAP_CopyOptionToList(CoAP_option_t** pOptionsListBegin, CoAP_opti
 CoAP_Result_t CoAP_RemoveOptionFromList(CoAP_option_t** pOptionListStart, CoAP_option_t* pOptionToRemove);
 CoAP_Result_t CoAP_FreeOptionList(CoAP_option_t** pOptionsListBegin);
 
+CoAP_Result_t CoAP_GetUintFromOption(const CoAP_option_t* pOption, uint32_t* value);
+
 bool CoAP_OptionsAreEqual(CoAP_option_t* OptA, CoAP_option_t* OptB);
 uint16_t CoAP_CheckForUnknownCriticalOption(CoAP_option_t* pOptionsListBegin);
 


### PR DESCRIPTION
A Simple feature to store the uint value of an `CoAP_option_t` into a pointer argument