### PR TITLE
Pass along resource `CoAP_Res_t` as a member of `CoAP_Message_t`

### DIFF
--- a/src/coap_interaction.c
+++ b/src/coap_interaction.c
@@ -372,6 +372,9 @@ CoAP_Result_t _rom CoAP_StartNewServerInteraction(CoAP_Message_t* pMsgReq, CoAP_
 	NetEp_t* pReqEp = &(pPacket->remoteEp);
 	CoAP_Interaction_t* pIA;
 
+	//Set the CoAP resource to the requst message
+	pMsgReq->pResource = pRes;
+
 	//duplicate detection:
 	//same request already received before?
 	//iterate over all interactions

--- a/src/liblobaro_coap.h
+++ b/src/liblobaro_coap.h
@@ -236,6 +236,9 @@ typedef struct {
 	uint8_t Token[8];
 } CoAP_Token_t;
 
+// Delcare CoAP_Res so it can be used in CoAP_Message_t
+struct CoAP_Res;
+
 typedef struct {
 	uint32_t Timestamp; //set by parse/send network routines
 	//VER is implicit = 1
@@ -248,6 +251,8 @@ typedef struct {
 	CoAP_Token_t Token;                         // [9] Token (1 byte Length + up to 8 Byte for the token content)
 	CoAP_option_t* pOptionsList;                // [4] linked list of Options
 	uint8_t* Payload;                           // [4] MUST be last in struct! Because of mem allocation scheme which tries to allocate message mem and payload mem in ONE big data chunk
+
+	struct CoAP_Res* pResource;                      // Pointer the the resource this message is intended for.
 } CoAP_Message_t; //total of 25 Bytes
 
 //################################


### PR DESCRIPTION
This closes #14. 
The idea is to pass along the CoAP resource (`CoAP_Res_t`) as a member of `CoAP_Message_t` in the request message for the callback handler. 
To the request which can be used in a shared callback to easily identify which resource to process. Instead of implementing a single callback for each and every CoAP resource. 

*Edit:* No longer a breaking change 👼 