### PR TITLE
Add support for RFC 8132 (FETCH, PATCH, iPATCH methods)

### DIFF
--- a/src/coap_interaction.c
+++ b/src/coap_interaction.c
@@ -259,7 +259,7 @@ CoAP_Result_t _rom CoAP_StartNewGetRequest(char* UriString, SocketHandle_t socke
 }
 
 CoAP_Result_t _rom CoAP_StartNewRequest(CoAP_MessageCode_t type, const char* UriString, SocketHandle_t socketHandle, NetEp_t* ServerEp, CoAP_RespHandler_fn_t cb, uint8_t *buf, size_t size) {
-	if (type != REQ_GET && type != REQ_POST && type != REQ_PUT && type != REQ_DELETE) {
+	if (type == EMPTY || type > REQ_LAST) {
 		ERROR("- Invalid request type\r\n");
 		return COAP_ERR_ARGUMENT;
 	}

--- a/src/coap_main.c
+++ b/src/coap_main.c
@@ -385,6 +385,9 @@ static void handleServerInteraction(CoAP_Interaction_t* pIA) {
 				|| ((pIA->pReqMsg->Code == REQ_POST) && !((pIA->pRes->Options).AllowedMethods & RES_OPT_POST))
 				|| ((pIA->pReqMsg->Code == REQ_PUT) && !((pIA->pRes->Options).AllowedMethods & RES_OPT_PUT))
 				|| ((pIA->pReqMsg->Code == REQ_DELETE) && !((pIA->pRes->Options).AllowedMethods & RES_OPT_DELETE))
+				|| ((pIA->pReqMsg->Code == REQ_FETCH) && !((pIA->pRes->Options).AllowedMethods & RES_OPT_FETCH))
+				|| ((pIA->pReqMsg->Code == REQ_PATCH) && !((pIA->pRes->Options).AllowedMethods & RES_OPT_PATCH))
+				|| ((pIA->pReqMsg->Code == REQ_IPATCH) && !((pIA->pRes->Options).AllowedMethods & RES_OPT_IPATCH))
 				) {
 			pIA->pRespMsg = CoAP_AllocRespMsg(pIA->pReqMsg, RESP_METHOD_NOT_ALLOWED_4_05, 0); //matches also TYPE + TOKEN to request
 
@@ -480,7 +483,7 @@ static void handleServerInteraction(CoAP_Interaction_t* pIA) {
 		}
 
 		//handle for GET observe option
-		if (pIA->pReqMsg->Code == REQ_GET && pIA->pRespMsg->Code == RESP_SUCCESS_CONTENT_2_05) {
+		if ((pIA->pReqMsg->Code == REQ_GET || pIA->pReqMsg->Code == REQ_FETCH) && pIA->pRespMsg->Code == RESP_SUCCESS_CONTENT_2_05) {
 			CoAP_Result_t result = CoAP_HandleObservationInReq(pIA);
 			if (result == COAP_OK) { //<---- attach OBSERVER to resource
 				AddObserveOptionToMsg(pIA->pRespMsg, 0);  //= ACK observation to client

--- a/src/coap_message.c
+++ b/src/coap_message.c
@@ -609,8 +609,14 @@ const char _rom *CoAP_CodeName(CoAP_MessageCode_t code) {
 		case REQ_PUT:
 			return "REQ_PUT";
 		case REQ_DELETE:
-			// DELETE and LAST both 0.04
-			return "REQ_DELETE/REQ_LAST";
+			return "REQ_DELETE";
+		case REQ_FETCH:
+			return "REQ_FETCH";
+		case REQ_PATCH:
+			return "REQ_PATCH";
+		case REQ_IPATCH:
+			// iPATCH and LAST both 0.07
+			return "REQ_IPATCH/REQ_LAST";
 		case RESP_FIRST_2_00:
 			return "RESP_FIRST_2_00";
 		case RESP_SUCCESS_CREATED_2_01:

--- a/src/liblobaro_coap.h
+++ b/src/liblobaro_coap.h
@@ -212,7 +212,10 @@ typedef enum {
 	REQ_POST = CODE(0u, 2u),
 	REQ_PUT = CODE(0u, 3u),
 	REQ_DELETE = CODE(0u, 4u),
-	REQ_LAST = CODE(0u, 4u),
+	REQ_FETCH = CODE(0u, 5u),
+	REQ_PATCH = CODE(0u, 6u),
+	REQ_IPATCH = CODE(0u, 7u),
+	REQ_LAST = CODE(0u, 7u),
 	RESP_FIRST_2_00 = CODE(2u, 0u),
 	RESP_SUCCESS_CREATED_2_01 = CODE(2u, 1u),    // only used on response to "POST" and "PUT" like HTTP 201
 	RESP_SUCCESS_DELETED_2_02 = CODE(2u, 2u),    // only used on response to "DELETE" and "POST" like HTTP 204
@@ -286,6 +289,9 @@ typedef struct CoAP_Observer {
 #define RES_OPT_POST   (1 << REQ_POST)   // 1<<2
 #define RES_OPT_PUT    (1 << REQ_PUT)    // 1<<3
 #define RES_OPT_DELETE (1 << REQ_DELETE) // 1<<4
+#define RES_OPT_FETCH  (1 << REQ_FETCH)  // 1<<5
+#define RES_OPT_PATCH  (1 << REQ_PATCH)  // 1<<6
+#define RES_OPT_IPATCH (1 << REQ_IPATCH) // 1<<7
 
 typedef enum {
 	HANDLER_OK = 0,


### PR DESCRIPTION
This provides support for the CoAP request methods FETCH, PATCH, and iPATCH.

[FETCH enforces the usage of the Content-Format option](https://datatracker.ietf.org/doc/html/rfc8132#section-2.3.1). I wasn't sure, if and where to add that as a check.